### PR TITLE
Fixing build for Linux/Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ grwrld.grayworld(clip input, int "opt", int "cc")
         - Git
         - C++17 compiler
         - CMake >= 3.16
+        - avisynthplus
     ```
 
     CMake options:

--- a/src/avs/grayworld_avs.h
+++ b/src/avs/grayworld_avs.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "avisynth.h"
+#include "avisynth/avisynth.h"
 #include "../common/common.h"
 
 template <grayworld_mode mode>


### PR DESCRIPTION
Add avisynthplus as a dependency and fix the header on the file src/avs/grayworld_avs.h Fixes #3